### PR TITLE
Fix Mock Database Filtering

### DIFF
--- a/src/app/database/mock-database-manager.service.ts
+++ b/src/app/database/mock-database-manager.service.ts
@@ -45,9 +45,7 @@ export class MockDatabaseManagerService extends DatabaseManagerService {
     const demoUser = new User('demo');
     demoUser.name = 'demo';
     demoUser.setNewPassword('pass');
-    const demoUserData = JSON.parse(JSON.stringify(demoUser));
-    demoUserData._id = demoUser.getType() + ':' + demoUser.name;
-    this.database.put(demoUserData);
+    entityMapper.save(demoUser);
 
     DemoData.getAllDemoEntities()
       .forEach(c => entityMapper.save(c));

--- a/src/app/latest-changes/app-version/app-version.component.ts
+++ b/src/app/latest-changes/app-version/app-version.component.ts
@@ -44,13 +44,13 @@ export class AppVersionComponent implements OnInit {
     this._sessionService.onSessionStatusChanged.subscribe(
       (sessionStatus: SessionStatus) => {
         if (sessionStatus === SessionStatus.loggedIn) {
-          this.checkForUpdatedVersion();
+          setTimeout(() => this.checkForUpdatedVersion());
         }
       }
     );
 
     // do initial check
-    this.checkForUpdatedVersion();
+    setTimeout(() => this.checkForUpdatedVersion());
   }
 
   checkForUpdatedVersion() {


### PR DESCRIPTION
Plain Objects cause issues on filtering for the dashboard. The User is not set through the EntityManager and is just a plain Object, as opposed to all other objects from demo-data.ts.

This Pull Request changes the code, so the User is a real object and filtering works.

see issue: #167, #169

