### PR TITLE
generate explicit, overwritable search indices for entities

### DIFF
--- a/src/app/children/child.ts
+++ b/src/app/children/child.ts
@@ -88,6 +88,19 @@ export class Child extends Entity {
     return this.name;
   }
 
+  public generateSearchIndices(): string[] {
+    let indices = [];
+
+    if (this.name !== undefined) {
+      indices = indices.concat(this.name.split(' '));
+    }
+    if (this.projectNumber !== undefined) {
+      indices.push(this.projectNumber);
+    }
+
+    return indices;
+  }
+
   public getPhoto() {
     if (!this.hasPhoto) {
       return 'assets/child.png';

--- a/src/app/entity/entity.ts
+++ b/src/app/entity/entity.ts
@@ -77,8 +77,19 @@ export class Entity {
     return Object.assign(this, data);
   }
 
+  /**
+   * Returns an object cleaned for export or writing to the database.
+   *
+   * Generates the current search indices for the returned object.
+   *
+   * <b>Overwrite this method in subtypes if you need to convert some special property before saving.</b>
+   *
+   * @returns {object} the instance's cleaned object.
+   */
   public rawData(): any {
-    return this;
+    const data = this;
+    data['searchIndices'] = this.generateSearchIndices();
+    return data;
   }
 
   /**
@@ -88,8 +99,28 @@ export class Entity {
    *
    * @returns {string} the instance's string representation.
    */
-  public toString() {
+  public toString(): string {
     return this.getId();
+  }
+
+  /**
+   * Returns an array of strings by which the entity can be searched.
+   *
+   * By default the parts of the "name" property (split at spaces) is used if it is present.
+   *
+   * <b>Overwrite this method in subtypes if you want an entity type to be searchable by other properties.</b>
+   *
+   * @returns {string[]} an array of strings through which the entity can be searched.
+   */
+  public generateSearchIndices(): string[] {
+    let indices = [];
+
+    // default indices generated from "name" property
+    if (this.hasOwnProperty('name')) {
+      indices = this['name'].split(' ');
+    }
+
+    return indices;
   }
 
   public getColor() {

--- a/src/app/ui/search/search.component.ts
+++ b/src/app/ui/search/search.component.ts
@@ -23,8 +23,8 @@ export class SearchComponent implements OnInit {
   private createSearchIndex() {
     // `emit(x)` to add x as a key to the index that can be searched
     const searchMapFunction = 'function searchMapFunction (doc) {' +
-'if (doc.hasOwnProperty("name")) {doc.name.toLowerCase().split(" ").forEach(word => emit(word));}' +
-'if (doc.hasOwnProperty("projectNumber")) { emit(doc.projectNumber); }  }';
+      'if (doc.hasOwnProperty("searchIndices")) { doc.searchIndices.forEach(word => emit(word.toString().toLowerCase())) }' +
+      '}';
 
     const designDoc = {
       _id: '_design/search_index',
@@ -71,7 +71,7 @@ export class SearchComponent implements OnInit {
   }
 
   private containsSecondarySearchTerms(item, searchTerms: string[]) {
-    const itemKey = (item.toString() + ' ' + item.getId()).toLowerCase();
+    const itemKey = item.generateSearchIndices().join(' ').toLowerCase();
     for (let i = 1; i < searchTerms.length; i++) {
       if (!itemKey.includes(searchTerms[i])) {
         return false;


### PR DESCRIPTION
see issue: #157

Generalized the search term logic to make it easily and elegantly extendable by different Entity types.

### Visible/Frontend Changes
_None_

### Architectural/Backend Changes
- [x] added `generateSearchIndices()` function to `Entity` base class to define search terms of entity types. Changed `SearchComponent` to use these searchIndices for search instead of hard-coded properties of the objects.
- [x] allows `gerateSearchIndices` to be overwritten in subclasses to define a custom search logic for an entity type).
- [x] defined default search indices: if a `name` property` exists for an entity subclass, the name is split at whitespaces and the parts used as search terms
- [x] defined custom search indices for `Child` entities: searchable by `name` parts and by `projectNumber`