### PR TITLE
Properly close Sync Status Dialog in tests

### DIFF
--- a/src/app/sync-status/sync-status/sync-status.component.spec.ts
+++ b/src/app/sync-status/sync-status/sync-status.component.spec.ts
@@ -78,7 +78,9 @@ describe('SyncStatusComponent', () => {
 
     function checkDialogRefDefined(_expect, _done) {
       _expect(component.dialogRef).toBeDefined();
-      _done();
+      component.dialogRef.close();
+      fixture.detectChanges();
+      fixture.whenStable().then(_done());
     }
   });
 });


### PR DESCRIPTION
Run `npm run test`. Before this change (i.e. on master), after the tests successfully ran, the Sync Status Dialog was not closed. After this change, it is.

Adapted from 12d3e8fd5552e3449ec502548632343bca1717b8